### PR TITLE
Add Packer container image

### DIFF
--- a/packer/Dockerfile
+++ b/packer/Dockerfile
@@ -1,0 +1,22 @@
+ARG DEBIAN
+
+FROM debian:${DEBIAN}
+
+ARG ANSIBLE
+ARG PACKER
+
+RUN apt-get update \
+  && apt-get install -y python3-pip python3-dev wget jq git ca-certificates openssh-client sed openssl unzip \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 install --upgrade pip \
+  && pip install ansible==${ANSIBLE}
+
+RUN cd /tmp \
+  && wget -O /tmp/packer.zip \
+    "https://releases.hashicorp.com/packer/${PACKER}/packer_${PACKER}_linux_amd64.zip" \
+  && unzip -o /tmp/packer.zip -d /usr/local/bin \
+  && rm -f /tmp/packer.zip \
+  && groupadd -r packer && useradd -r -m -g packer packer
+
+USER packer

--- a/packer/spec.yaml
+++ b/packer/spec.yaml
@@ -1,0 +1,8 @@
+image: sighup/packer
+tags:
+  ANSIBLE:
+    - 2.8.5
+  PACKER:
+    - 1.4.4
+  DEBIAN:
+    - 10


### PR DESCRIPTION
Hi team!

I were looking for a Packer container image and i didn't found one. So, i have created a packer image with ansible preinstalled.

It also creates a non privileged user to make it possible running ansible playbooks.

Note: If you run ansible-playbook as root, `become` flag will not work as expected. Source [packer docs](https://www.packer.io/docs/provisioners/ansible.html#become-yes)

Thanks!