### PR TITLE
Add new kind container image with static kubernetes versions

### DIFF
--- a/kind/Dockerfile
+++ b/kind/Dockerfile
@@ -1,13 +1,13 @@
 FROM docker:dind
 
-ARG KUBECTL
+ARG KUBERNETES
 ARG KUSTOMIZE
 ARG KIND
 RUN apk add --no-cache git make musl-dev go jq curl bash nodejs nodejs-npm openssl \
   && curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND}/kind-linux-amd64 && chmod +x kind && mv kind /usr/local/bin/ \
   && npm install -g bats \
-  && curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/ \
-  && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE}/kustomize_${KUSTOMIZE}_linux_amd64 -o /usr/local/bin/kustomize \
+  && curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/ \
+  && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE}/kustomize_kustomize.v${KUSTOMIZE}_linux_amd64 -o /usr/local/bin/kustomize \
   && chmod +x /usr/local/bin/kustomize && kustomize version
 
 WORKDIR /tests
@@ -16,5 +16,6 @@ COPY kind-config-${KIND} /kind-config
 COPY setup.sh .
 ENTRYPOINT ["bash", "-c"]
 ENV NAME test
+ENV K8S_VERSION ${KUBERNETES}
 CMD ["bash /tests/setup.sh && export KUBECONFIG=\"$(kind get kubeconfig-path --name=\"$NAME\")\" && bats -p $TESTS"]
 

--- a/kind/kind-config-v0.5.1
+++ b/kind/kind-config-v0.5.1
@@ -1,0 +1,16 @@
+apiVersion: kind.sigs.k8s.io/v1alpha3
+kind: Cluster
+networking:
+  apiServerAddress: "0.0.0.0"
+
+kubeadmConfigPatchesJson6902:
+- group: kubeadm.k8s.io
+  version: v1beta2
+  kind: ClusterConfiguration
+  patch: |
+    - op: add
+      path: /apiServer/certSANs/-
+      value: docker
+nodes:
+- role: control-plane
+- role: worker

--- a/kind/setup.sh
+++ b/kind/setup.sh
@@ -3,7 +3,8 @@ echo "waiting for docker to start"
 let i=0; while ! docker ps; do let i=i+1; [ $i -le 12 ] || exit 1 && sleep 5; done || exit 1
 set -e
 kind create cluster --name "$NAME" --config /kind-config --image kindest/node:${K8S_VERSION} --wait 1m --loglevel=debug
-export KUBECONFIG="$(kind get kubeconfig-path --name="$NAME")"
+kind get kubeconfig --name "$NAME" > /kubeconfig
+export KUBECONFIG=/kubeconfig
 sed -i -E -e 's/localhost|0\.0\.0\.0/'"$CLUSTER_HOST"'/g' "$KUBECONFIG"
 kubectl apply -f - <<EOF
 ---

--- a/kind/setup.sh
+++ b/kind/setup.sh
@@ -2,7 +2,7 @@
 echo "waiting for docker to start"
 let i=0; while ! docker ps; do let i=i+1; [ $i -le 12 ] || exit 1 && sleep 5; done || exit 1
 set -e
-kind create cluster --name "$NAME" --config /kind-config --wait 1m --loglevel=debug
+kind create cluster --name "$NAME" --config /kind-config --image kindest/node:${K8S_VERSION} --wait 1m --loglevel=debug
 export KUBECONFIG="$(kind get kubeconfig-path --name="$NAME")"
 sed -i -E -e 's/localhost|0\.0\.0\.0/'"$CLUSTER_HOST"'/g' "$KUBECONFIG"
 kubectl apply -f - <<EOF

--- a/kind/spec.yaml
+++ b/kind/spec.yaml
@@ -1,9 +1,13 @@
 image: sighup/kind
 tags:
-  KUBECTL:
-    - v1.12.0
   KUSTOMIZE:
-    - 1.0.10
+    - 3.2.2
   KIND:
     - v0.3.0
     - v0.4.0
+    - v0.5.1
+  KUBERNETES:
+    - v1.13.10
+    - v1.14.6
+    - v1.15.3
+    - v1.16.2


### PR DESCRIPTION
Hi team!

Merging this pull request, we will be sure about the kubernetes version we will use in test pipelines.

Change log:

- Updates kustomize version.
- Updates kind version.
- Align kubectl version with the kubernetes version created with kind.

The "new" configuration file has been tested locally with kind 0.5.1.

Thanks!