### PR TITLE
FIX: Version v1beta2 has been deprecated in 1.16 k8s version

### DIFF
--- a/kind/setup.sh
+++ b/kind/setup.sh
@@ -115,7 +115,7 @@ subjects:
     namespace: default
 ---
 # Source: hostpath-provisioner/templates/deployment.yaml
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: release-name-hostpath-provisioner


### PR DESCRIPTION
Hi!

We found an error while trying to spin up a new kind 1.16 cluster.

It's related to the `hostpath provisioner` we deploy on a new kind cluster.

It has `v1beta2` `app` version, switching to `v1` should fix the problem

Thanks!