### PR TITLE
FIX: kind get kubeconfig-path deprecation

### DIFF
--- a/kind/Dockerfile
+++ b/kind/Dockerfile
@@ -17,5 +17,5 @@ COPY setup.sh .
 ENTRYPOINT ["bash", "-c"]
 ENV NAME test
 ENV K8S_VERSION ${KUBERNETES}
-CMD ["bash /tests/setup.sh && export KUBECONFIG=\"$(kind get kubeconfig-path --name=\"$NAME\")\" && bats -p $TESTS"]
+CMD ["bash /tests/setup.sh && export KUBECONFIG=/kubeconfig && bats -p $TESTS"]
 


### PR DESCRIPTION
Hi Team.

@phisco found another reference to the `kind get kubeconfig-path` command, it is going to be deprecated soon, so it's important to replace it.

Thanks!