### PR TITLE
Add local provisioner storage class to kind clusters

### DIFF
--- a/kind/setup.sh
+++ b/kind/setup.sh
@@ -6,4 +6,165 @@ kind create cluster --name "$NAME" --config /kind-config --image kindest/node:${
 kind get kubeconfig --name "$NAME" > /kubeconfig
 export KUBECONFIG=/kubeconfig
 sed -i -E -e 's/localhost|0\.0\.0\.0/'"$CLUSTER_HOST"'/g' "$KUBECONFIG"
-sleep 5
+# Marking default storage class as non-default storage class
+kubectl get sc --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | xargs -I {} kubectl annotate sc {} storageclass.beta.kubernetes.io/is-default-class="false" --overwrite
+# Creating a new default storage
+kubectl apply -f - <<EOF
+---
+# Source: hostpath-provisioner/templates/storageclass.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hostpath
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: hostpath
+
+---
+# Source: hostpath-provisioner/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-name-hostpath-provisioner
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+---
+# Source: hostpath-provisioner/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-name-hostpath-provisioner
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+---
+# Source: hostpath-provisioner/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-name-hostpath-provisioner
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-name-hostpath-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: release-name-hostpath-provisioner
+    namespace: default
+---
+# Source: hostpath-provisioner/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-name-hostpath-provisioner-leader-locking
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["list", "watch", "create"]
+---
+# Source: hostpath-provisioner/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-name-hostpath-provisioner-leader-locking
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-name-hostpath-provisioner-leader-locking
+subjects:
+  - kind: ServiceAccount
+    name: release-name-hostpath-provisioner
+    namespace: default
+---
+# Source: hostpath-provisioner/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-name-hostpath-provisioner
+  labels:
+    app.kubernetes.io/name: hostpath-provisioner
+    helm.sh/chart: hostpath-provisioner-0.2.3
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Tiller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hostpath-provisioner
+      app.kubernetes.io/instance: release-name
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hostpath-provisioner
+        app.kubernetes.io/instance: release-name
+    spec:
+      serviceAccountName: release-name-hostpath-provisioner
+      containers:
+        - name: hostpath-provisioner
+          image: "quay.io/rimusz/hostpath-provisioner:v0.2.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: pv-volume
+              mountPath: /mnt/hostpath
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+
+      volumes:
+        - name: pv-volume
+          hostPath:
+            path: /mnt/hostpath
+EOF
+sleep 20


### PR DESCRIPTION
Hi team.

We tried #26 to use the default storage provided by kind. But, seems like is not working in latest revision 0.5.1. 

It's broken if you use `subpath` feature, so we have to deploy our own storage class provider (local path provider from rancher).

It solves the problems with the monitoring package (prometheus uses `subpath` directory mount).

Links: 
- https://github.com/kubernetes-sigs/kind/issues/118
- https://github.com/kubernetes-sigs/kind/issues/403
- https://github.com/kubeflow/website/issues/749


Thanks!