### PR TITLE
Upgrade katalog container image with kustomize version 3

### DIFF
--- a/katalog/spec.yaml
+++ b/katalog/spec.yaml
@@ -3,4 +3,4 @@ tags:
   PYTHON:
     - 3
   KUSTOMIZE:
-    - 1.0.10
+    - 3.2.2


### PR DESCRIPTION
Hi team.

As part of our journey to upgrade kustomize from 1 -> 3 i found an image (that i use in other pipeline) with an old kustomize version. This is caused my some problems in some pipelines.

Let's try to update the image we found.

Thanks!