### PR TITLE
FIX: Change github releases kustomize url

### DIFF
--- a/katalog/Dockerfile
+++ b/katalog/Dockerfile
@@ -2,6 +2,6 @@ ARG PYTHON
 FROM python:${PYTHON}
 ARG KUSTOMIZE
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
-RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE}/kustomize_${KUSTOMIZE}_linux_amd64 -o /usr/local/bin/kustomize && chmod +x /usr/local/bin/kustomize && kustomize version
+RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE}/kustomize_kustomize.v${KUSTOMIZE}_linux_amd64 -o /usr/local/bin/kustomize && chmod +x /usr/local/bin/kustomize && kustomize version
 COPY test-requirements.txt .
 RUN pip install -r test-requirements.txt


### PR DESCRIPTION
Hi team, 

sorry, the last PR #28 didn't pass the CI because kustomize repo changed the release URL from version 1 to -> 3.

Thanks team!