### PR TITLE
Update container image to use 3.2.2 kustomize version

### DIFF
--- a/furyctl-bats/Dockerfile
+++ b/furyctl-bats/Dockerfile
@@ -1,6 +1,9 @@
 ARG FURYCTL
 FROM sighup/furyctl:${FURYCTL}
+RUN apk add --no-cache bash nodejs npm curl && npm install -g bats
+
 ARG KUSTOMIZE
-RUN apk add --no-cache bash nodejs npm curl && npm install -g bats \
-  && curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE}/kustomize_${KUSTOMIZE}_linux_amd64 -o /usr/local/bin/kustomize \
-  && chmod +x /usr/local/bin/kustomize && kustomize version
+
+RUN curl -LOs https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE}/kustomize_kustomize.v${KUSTOMIZE}_linux_amd64 && \
+    chmod +x kustomize_kustomize.v${KUSTOMIZE}_linux_amd64 && \
+    mv kustomize_kustomize.v${KUSTOMIZE}_linux_amd64 /usr/local/bin/kustomize &&  kustomize version

--- a/furyctl-bats/spec.yaml
+++ b/furyctl-bats/spec.yaml
@@ -1,6 +1,8 @@
 image: sighup/furyctl-bats
 tags:
   FURYCTL:
-    - v0.1.0
+    - v0.1.1
+    - v0.1.2
+    - v0.1.3
   KUSTOMIZE:
-    - 1.0.10
+    - 3.2.2


### PR DESCRIPTION
Hi again team.

This PR depends on #35 as it uses a base that has to be built before this new container images.

As we are moving from kustomize 1 to kustomize 3, we need it ;)

Thanks!