### PR TITLE
jenkins-agent-kubectl: add git-crypt

### DIFF
--- a/jenkins-agent-kubectl/Dockerfile
+++ b/jenkins-agent-kubectl/Dockerfile
@@ -14,6 +14,7 @@ RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KU
     kustomize version
 
 USER root
-RUN  apt-get update -y
-RUN  apt-get install -y git-crypt
+RUN  apt-get update -y && \
+     apt-get install -y git-crypt && \
+     rm -rf /var/lib/apt/lists/*
 USER jenkins

--- a/jenkins-agent-kubectl/Dockerfile
+++ b/jenkins-agent-kubectl/Dockerfile
@@ -1,8 +1,8 @@
 FROM jenkins/jnlp-slave:3.27-1
 
-
 RUN mkdir -p /home/jenkins/bin
 ENV PATH=$PATH:/home/jenkins/bin
+
 ARG KUBECTL
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL}/bin/linux/amd64/kubectl -o /home/jenkins/bin/kubectl && \
     chmod +x /home/jenkins/bin/kubectl && \
@@ -12,3 +12,8 @@ ARG KUSTOMIZE
 RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE}/kustomize_${KUSTOMIZE}_linux_amd64 -o /home/jenkins/bin/kustomize && \
     chmod +x /home/jenkins/bin/kustomize && \
     kustomize version
+
+USER root
+RUN  apt-get update -y
+RUN  apt-get install -y git-crypt
+USER jenkins


### PR DESCRIPTION
Major credit to @Procras 

This MR enables usage of `git-crypt` inside Jenkins pipelines executed by this jenkins-agent.
Note that jenkins-agent image already contains `gpg`.
Thus, the integration with `git-crypt` can work as follows:
- create a new GPG key `key`
- add `key` as git-crypt collaborator to a project for which you're building a pipeline
- add `key` (private key) inside the jenkins-agent container, to the gpg keyring

You should now be able to execute `git-crypt unlock` inside Jenkins pipelines. 