### PR TITLE
Flux: Add ver 1.18.0

### DIFF
--- a/flux-git-crypt/spec.yaml
+++ b/flux-git-crypt/spec.yaml
@@ -2,5 +2,6 @@ image: sighup/flux-git-crypt
 tags:
   FLUX:
     - 1.15.0
+    - 1.18.0
   KUSTOMIZE:
     - 1.0.10


### PR DESCRIPTION
So that we can take advantage from various bug/sec fixes and improvements, notably:
"The pressure on the Kubernetes API server has been reduced when Flux operates in all namespaces"