### PR TITLE
fix: added decoding of gitCrypt

### DIFF
--- a/furyplatform-furyctl-runner/spec.yaml
+++ b/furyplatform-furyctl-runner/spec.yaml
@@ -1,4 +1,4 @@
 image: sighup/furyplatform-furyctl-runner
 tags:
   VERSION:
-    - 0.0.6
+    - 0.0.7

--- a/furyplatform-furyctl-runner/src/create.sh
+++ b/furyplatform-furyctl-runner/src/create.sh
@@ -33,15 +33,15 @@ notify() {
     else
         message="{\"channel\":\"${SLACK_CHANNEL}\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"Your cluster *${CLUSTER_FULL_NAME}* creation has failed :flushed:\"}}]}"
     fi
-    
+
     echo "📬  sending Slack notification... "
-    
+
     curl -H "Content-type: application/json" \
     --data  "${message}" \
     -H "Authorization: Bearer ${SLACK_TOKEN}" \
     --output /dev/null -s \
     -X POST https://slack.com/api/chat.postMessage
-    
+
     exit ${JOB_RESULT}
 }
 
@@ -131,11 +131,12 @@ fi
 # If we find a git crypt key, let's unlock the repo.
 if [[ -f "/var/git-crypt.key" ]]; then
     echo "🔐  unlocking the git repo"
-    git-crypt unlock /var/git-crypt.key
+    cat /var/git-crypt.key  | base64 -d > /tmp/git-crypt.key
+    git-crypt unlock /tmp/git-crypt.key
     if [ $? -ne 0 ]; then
         JOB_RESULT=1
     fi
-    
+
 fi
 
 mkdir -p $WORKDIR


### PR DESCRIPTION
Hi everyone 👋 
as we discussed yesterday, I've added the decoding line for gitCrypt because of  https://pkg.go.dev/encoding/json#Marshal:

```
Array and slice values encode as JSON arrays, except that []byte encodes as a base64-encoded string, and a nil slice encodes as the null JSON value.

```