### PR TITLE
feat: add etcd-backupper image

### DIFF
--- a/etcd-backupper/Dockerfile
+++ b/etcd-backupper/Dockerfile
@@ -1,7 +1,19 @@
-FROM alpine:3.21
+ARG ALPINE
+FROM alpine:${ALPINE}
 
-RUN apk add etcd-ctl yq
+ARG ETCD_VER=v3.5.19
+
+RUN apk add curl yq
+
+RUN mkdir /tmp/etcd-download-test
+
+RUN curl -L https://github.com/etcd-io/etcd/releases/download/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz -o /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz && \
+    tar xzvf /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz -C /tmp/etcd-download-test --strip-components=1 && \
+    rm -f /tmp/etcd-${ETCD_VER}-linux-amd64.tar.gz && \
+    mv /tmp/etcd-download-test/etcdctl /usr/local/bin/etcdctl && \
+    etcdctl version
 
 COPY init.sh /init.sh
 
 ENTRYPOINT ["/init.sh"]
+

--- a/etcd-backupper/Dockerfile
+++ b/etcd-backupper/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.21
+
+RUN apk add etcd-ctl yq
+
+COPY init.sh /init.sh
+
+ENTRYPOINT ["/init.sh"]

--- a/etcd-backupper/README.md
+++ b/etcd-backupper/README.md
@@ -1,0 +1,10 @@
+# etcd-backupper
+A simple Alpine-based image which contains `etcdctl` and `yq` to
+assist the `etcd-backup-*` features.
+
+## Endpoint detection
+There is some logic to try to automatically detect which endpoints
+are the `etcd` server listening on, but in order to make this work
+you have to mount the `ClusterConfiguration` config-map as a volume
+under `/k8s/config.yaml`. If this isn't mounted, there's a fallback
+endpoint (`https://127.0.0.1:2379`).

--- a/etcd-backupper/init.sh
+++ b/etcd-backupper/init.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+CONFIG_FILE="/k8s/config.yaml"
+ETCDCTL_ENDPOINTS="https://127.0.0.1:2379"
+
+if [ -f "$CONFIG_FILE" ]; then
+    ENDPOINTS=$(yq eval '.etcd.external.endpoints | join(",")' "$CONFIG_FILE")
+    
+    [ -n "$ENDPOINTS" ] && ETCDCTL_ENDPOINTS="$ENDPOINTS"
+fi
+
+ETCDCTL_API=3 \
+ETCDCTL_ENDPOINTS="$ETCDCTL_ENDPOINTS" \
+ETCDCTL_CACERT="$ETCDCTL_CACERT" \
+ETCDCTL_CERT="$ETCDCTL_CERT" \
+ETCDCTL_KEY="$ETCDCTL_KEY" \
+etcdctl snapshot save /backup/fury-etcd-snapshot-$(date +'%Y%m%d%H%M').etcdb

--- a/etcd-backupper/spec.yaml
+++ b/etcd-backupper/spec.yaml
@@ -1,0 +1,6 @@
+image: sighup/etcdctl-alpine-yq
+tags:
+  ALPINE:
+    - 3.21
+  ETCD:
+    - v3.5.19


### PR DESCRIPTION
Add a new `etcd-backupper` image to aid the `etcd-backup-*` features.